### PR TITLE
fix(agent): correct event type literal in parser test

### DIFF
--- a/packages/agent/src/parser.test.ts
+++ b/packages/agent/src/parser.test.ts
@@ -71,7 +71,7 @@ describe('parseOperationCompletedMessage', () => {
     const result = parseOperationCompletedMessage(log)
     expect(result).toEqual({
       serverTimestamp: '51.889',
-      type: 'operationCompleted',
+      type: 'operationsCompleted',
     })
   })
 })


### PR DESCRIPTION
## Summary
- Fixed naming mismatch in `parseOperationCompletedMessage` test: the test expected `'operationCompleted'` (singular) but the interface, implementation, and message handler all use `'operationsCompleted'` (plural)
- This was the only consumer using the singular form — the test would fail at runtime

## Changes
- `packages/agent/src/parser.test.ts`: Changed expected type from `'operationCompleted'` to `'operationsCompleted'`

## Test plan
- [x] `pnpm run lint` passes
- [x] `pnpm run build && pnpm run typecheck` passes
- [x] `pnpm test` in agent package — all 6 tests pass

Fixes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)