### PR TITLE
fix(autorio): fix item transfer double-counting and placement inventory lookup

### DIFF
--- a/packages/autorio/src/control.ts
+++ b/packages/autorio/src/control.ts
@@ -609,7 +609,7 @@ function state_placing(player: LuaPlayer) {
     return [false, 'Invalid entity name']
   }
 
-  const [item_stack, unused_count] = inventory.find_item_stack(task_manager.player_state.parameters_place_entity.entity_name)
+  const [item_stack, unused_count] = inventory.find_item_stack(item_name.name)
   if (!item_stack) {
     log('[AUTORIO] Entity not found in inventory, ending PLACING task')
     task_manager.reset_task_state()
@@ -759,7 +759,6 @@ function state_moving_items(player: LuaPlayer) {
           moved_total += removed
         }
 
-        moved_total += removed
         log(`[AUTORIO] Moved ${removed} ${parameters.item_name} from ${inventory.entity_owner?.name} inventory index ${inventory.index}`)
       })
   }


### PR DESCRIPTION
## Summary
- **`state_moving_items`**: Fixed double-counting bug in entity-to-player transfer. Line 762 unconditionally added `removed` to `moved_total` after the if-else block (lines 756/759) already correctly accounted for it. This caused inflated totals and premature loop exits.
- **`state_placing`**: Fixed inventory lookup to use `item_name.name` (from `items_to_place_this[0]`) instead of `entity_name`. This fixes placement failures for entities whose placeable item name differs from the entity prototype name (e.g., `curved-rail` requiring `rail` item).

## Changes
- `packages/autorio/src/control.ts`:
  - Removed duplicate `moved_total += removed` (was line 762)
  - Changed `find_item_stack(entity_name)` to `find_item_stack(item_name.name)` in `state_placing`

## Test plan
- [x] `pnpm run lint` passes
- [x] `pnpm run build && pnpm run typecheck` passes (tstl validates `item_name.name` type)
- [ ] In-game: verify item transfer reports correct totals
- [ ] In-game: verify placement works for entities with different item names

Fixes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)